### PR TITLE
fix mailto prefix (doesn't need trailing // like other protocols)

### DIFF
--- a/data/1/rcf.txt
+++ b/data/1/rcf.txt
@@ -347,7 +347,7 @@ _locale_file = "%L%-%C";
   object_type=method;
   object_display_name=%locale.em.name;
   description_default=%locale.em.default;
-  prefix="mailto://";
+  prefix="mailto:";
   method_type=core
 );
 


### PR DESCRIPTION
a valid mailto link is `mailto:john@doe.com`, not `mailto://jon@doe.com`