### PR TITLE
1: remove name from link, use description

### DIFF
--- a/data/1/ecf.txt
+++ b/data/1/ecf.txt
@@ -16,7 +16,7 @@ config(
 
   l(
     label=A name and description helps to show what type of record the link leads to;
-    fields=(n(label=Enter a name for the link;placeholder=e.g. John Smith or Sales Department;priority=20);d(label=Enter a description for the link;placeholder=e.g. CTO;priority=10);@L(required=true;placeholder=`num://numexample.com/record`))
+    fields=(d(label=Enter a description for the link;placeholder=e.g. John Smith or Sales Department;priority=20);@L(required=true;placeholder=`num://numexample.com/record`))
   );
 
   @L(

--- a/data/1/rcf.txt
+++ b/data/1/rcf.txt
@@ -42,8 +42,7 @@ _locale_file = "%L%-%C";
   *superclass=contact;
   *assign=[
     [@L];
-    [n;@L];
-    [n;d;@L]
+    [d;@L];
   ]
 );
 


### PR DESCRIPTION
this is more consistent with how we do it for core contact methods (e.g.
telephone, web url)