### PR TITLE
Make image name optional

### DIFF
--- a/data/3/ecf.txt
+++ b/data/3/ecf.txt
@@ -5,7 +5,7 @@ config(
     fields=(i())
   );
   i(
-    fields(n(required=true);t(required=true);v(required=true))
+    fields(t(required=true);v(required=true))
   );
   v(
     fields(variant())


### PR DESCRIPTION
Populated records don't set an image name, I find myself typing "logo" for everyone I create, which is covered by the type. I still think it's a useful field let's say if I wanted to add multiple logos like "normal", "christmas", "BLM" but it should be optional.