### PR TITLE
1|2: Update how address is stored in modules 1 & 2

### DIFF
--- a/data/1/ecf.txt
+++ b/data/1/ecf.txt
@@ -102,7 +102,20 @@ config(
 
   al(
     component=textarea;
-    fields=(str())
+    fields=(str());
+    label=Enter the address, not including the postcode / zip or country;
+    required=true
+  );
+
+  pz(
+    label=Enter the postcode / zip;
+    required=true
+  );
+
+  co(
+    component=country;
+    label=Enter the country;
+    required=true
   );
 
   ac(
@@ -149,7 +162,7 @@ config(
   );
 
   a(
-    fields(al(label=Enter the lines of the address));
+    fields(al();pz();co());
     ignore=[v]
   );
 

--- a/data/1/rcf.txt
+++ b/data/1/rcf.txt
@@ -221,8 +221,22 @@ _locale_file = "%L%-%C";
   ## ADDRESS LINES: A method array value, e.g. the lines of an address
   *id=al;
   *name=lines;
-  *assign=[[v*]];
+  *assign=[[str*]];
   *superclass=arr
+);
+
+*class(
+  ## POSTCODE: The postcode part of an address, e.g. E14 5AB
+  *id=pz;
+  *name=postcode;
+  *superclass=str
+);
+
+*class(
+  ## COUNTRY: The country part of an address, e.g. GB
+  *id=co;
+  *name=country;
+  *superclass=str
 );
 
 *class(

--- a/data/2/ecf.txt
+++ b/data/2/ecf.txt
@@ -8,10 +8,10 @@ config(
     label=Is the owner an individual or an organisation?
   );
   i(
-    fields(n(label=Enter the individual's name);a();p();co();t();e();c())
+    fields(n(label=Enter the individual's name);a();t();e();c())
   );
   o(
-    fields(n(label=Enter the organisation's name);id();a();p();co();t();e();c())
+    fields(n(label=Enter the organisation's name);id();a();t();e();c())
   );
   n(
     label=Enter the name;
@@ -20,13 +20,17 @@ config(
   id(
     label="Enter an identifier for the organisation (e.g. company registration number)"
   );
+
   a(
+    fields(al();pz();co())
+  );
+  al(
     component=textarea;
     label=Enter the address, not including the postcode / zip or country;
-    fields(al());
+    fields(str());
     required=true
   );
-  p(
+  pz(
     label=Enter the postcode / zip;
     required=true
   );
@@ -48,6 +52,6 @@ config(
   contact(
     required=true;
     placeholder=Add a contact;
-    fields(n(label=Enter the name of the contact);a();p();co();t();e())
+    fields(n(label=Enter the name of the contact);a();t();e())
   )
 )

--- a/data/2/rcf.txt
+++ b/data/2/rcf.txt
@@ -21,18 +21,19 @@
   *superclass=str
 );
 *class(
-  *id=al;
-  *name=addressline;
-  *superclass=str
-);
-*class(
+  ## ADDRESS: A land / postal address.
   *id=a;
   *name=address;
-  *assign=[[al*]];
+  *superclass=map
+);
+*class(
+  *id=al;
+  *name=lines;
+  *assign=[[str*]];
   *superclass=arr
 );
 *class(
-  *id=p;
+  *id=pz;
   *name=postcode_zip;
   *superclass=str
 );


### PR DESCRIPTION
this commit brings standardisation across modules 1 & 2 in how the
address is formatted.

previously the address in the Contacts module (1) worked like this:
```
a(al[39th Floor;One Canada Square;Canary Wharf;London;E14 5AB)]
```

and in the WhoHas / Registrant module (2) it worked like this:
```
a[39th Floor;One Canada Square;Canary Wharf;London];p=E14 5AB;co=GB)
```

we wanted to standardise this as much as possible, so now the outcome in
the Contacts module (1) is like this:
```
a(al[39th Floor;One Canada Square;Canary Wharf;London];pz=E14 5AB;co=GB;d=London Office)
```

and in the WhoHas / Registrant module (2) like this:
```
a(al[39th Floor;One Canada Square;Canary Wharf;London];pz=E14 5AB;co=GB)
```

note the only difference being that the Contacts module (1) has an
optional description.